### PR TITLE
Fix can't drag immediately.   Add tweening back.

### DIFF
--- a/addons/simple_cards/card/card.gd
+++ b/addons/simple_cards/card/card.gd
@@ -130,6 +130,8 @@ func _on_button_up() -> void:
 		_on_mouse_exited()
 		_on_focus_exited()
 		if self.is_hovered():
+			_on_mouse_entered()
+		if self.has_focus():
 			_on_focus_entered()
 	else:
 		card_clicked.emit(self)


### PR DESCRIPTION
Add rotation and scale tweening back on card release.

Fix an issue where cards could not be dragged immediately after being dropped if the cursor remained on the card.