### PR TITLE
fix: allow containers to get size of lone card buttons

### DIFF
--- a/addons/simple_cards/card/card.gd
+++ b/addons/simple_cards/card/card.gd
@@ -113,9 +113,12 @@ func set_card_size():
 	if !_layout: return
 	if size != _layout.size:
 		size = _layout.size
+		custom_minimum_size = size
+
 	self_modulate.a = 0
 	center_pos = Vector2(size.x/2 , size.y/2)
 	pivot_offset = center_pos
+
 
 func _process(delta: float) -> void:
 	_drag(delta)


### PR DESCRIPTION
Similar to the issue with the CardHand, the Card object also doesn't define a custom minimum size. 

This is a fix that populates the field _custom_minimum_size()  whenever a card's size is update.

I have tested this fix in my local environment, and can confirm container nodes now correctly scale Cards that are by themselves.