### PR TITLE
Default card face templates to transparent bg

### DIFF
--- a/addons/simple_cards/card/card_layout/default_card_back_layout.tscn
+++ b/addons/simple_cards/card/card_layout/default_card_back_layout.tscn
@@ -22,6 +22,7 @@ script = ExtResource("1_ay1pi")
 metadata/_custom_type_script = "uid://dm115oleoggyt"
 
 [node name="SubViewport" type="SubViewport" parent="."]
+transparent_bg = true
 handle_input_locally = false
 size = Vector2i(80, 112)
 render_target_update_mode = 4

--- a/addons/simple_cards/card/card_layout/default_card_layout.tscn
+++ b/addons/simple_cards/card/card_layout/default_card_layout.tscn
@@ -22,6 +22,7 @@ script = ExtResource("1_0a68r")
 metadata/_custom_type_script = "uid://dm115oleoggyt"
 
 [node name="SubViewport" type="SubViewport" parent="."]
+transparent_bg = true
 handle_input_locally = false
 size = Vector2i(80, 112)
 render_target_update_mode = 4


### PR DESCRIPTION
Better default because I don't know what scenario someone would prefer to have a gray square behind the card sprite